### PR TITLE
fix: query camera and radar offline number (#29)

### DIFF
--- a/dandelion/api/api_v1/endpoints/cloud_homes.py
+++ b/dandelion/api/api_v1/endpoints/cloud_homes.py
@@ -59,13 +59,13 @@ def online_rate(
     camera_online_rate = {
         "online": 0,
         "offline": 0,
-        "notRegister": 0,
+        "notRegister": crud.camera.get_multi_with_total(db)[0],
     }
     # temporarily unavailable data
     radar_online_rate = {
         "online": 0,
         "offline": 0,
-        "notRegister": 0,
+        "notRegister": crud.radar.get_multi_with_total(db)[0],
     }
     return schemas.OnlineRate(
         **{


### PR DESCRIPTION
cherry pick: #29 
closes #26